### PR TITLE
Spanish and Portuguese localizataion of the README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,14 +156,14 @@ Display its Node ID and share it to allow connection
 
 ```
 ┌─────────────┐    ┌──────────────┐     ┌─────────────────┐     ┌─────────────┐
-│ iroh-ssh    │───▶│ internal TCP │───▶│ QUIC Tunnel     │───▶│ iroh-ssh    │
+│ iroh-ssh    │───▶│ internal TCP │────▶│ QUIC Tunnel     │────▶│ iroh-ssh    │
 │ (your machine)   │    Listener  │     │ (P2P Network)   │     │ server      │
 └─────────────┘    | (your machine)     └─────────────────┘     └─────────────┘
                    └──────────────┘
         │                  ▲                                           │
         ▼                  │                                           ▼
                    ┌──────────────┐                            ┌─────────────┐
-        ⦜   -- ▶  │ run:     ssh │                            │ SSH Server  │
+        ⦜   -- ▶   │ run:     ssh │                            │ SSH Server  │
                    │ user@localhost                            │ (port 22)   │
                    └──────────────┘                            └─────────────┘
 ```

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[Español](README_es.md)
 # iroh-ssh
 
 [![Crates.io](https://img.shields.io/crates/v/iroh-ssh.svg)](https://crates.io/crates/iroh-ssh)
@@ -34,7 +35,7 @@ cargo install iroh-ssh
 Download and setup the binary automatically for your operating system from [GitHub Releases](https://github.com/rustonbsd/iroh-ssh/releases):
 
 Linux
-```bash 
+```bash
 # Linux
 wget https://github.com/rustonbsd/iroh-ssh/releases/download/0.2.5/iroh-ssh.linux
 chmod +x iroh-ssh.linux
@@ -66,9 +67,9 @@ Verify that the installation was successful
 
 ---
 
-## Client Connection  
+## Client Connection
 
-```bash
+```bashPor el momento solo s
 # Install for your distro (see above)
 # Connect from anywhere
 > iroh-ssh my-user@38b7dc10df96005255c3beaeaeef6cfebd88344aa8c85e1dbfc1ad5e50f372ac
@@ -133,7 +134,7 @@ Display its Node ID and share it to allow connection
 
 ## Connection information
 ```bash
-// note: works only with persistent keys 
+// note: works only with persistent keys
 > iroh-ssh info
 
     Your iroh-ssh nodeid: 38b7dc10df96005255c3beaeaeef6cfebd88344aa8c85e1dbfc1ad5e50f372ac
@@ -142,7 +143,7 @@ Display its Node ID and share it to allow connection
 
     Your server iroh-ssh nodeid:
       iroh-ssh my-user@38b7dc10df96005255c3beaeaeef6cfebd88344aa8c85e1dbfc1ad5e50f372ac
-    
+
     Your service iroh-ssh nodeid:
       iroh-ssh my-user@4fjeeiui4jdm96005255c3begj389xk3aeaeef6cfebd88344aa8c85e1dbfc1ad
 ```
@@ -168,7 +169,7 @@ Display its Node ID and share it to allow connection
 ```
 
 1. **Client**: Creates local TCP listener, connects system SSH client to it
-2. **Tunnel**: QUIC connection through Iroh's P2P network (automatic NAT traversal)  
+2. **Tunnel**: QUIC connection through Iroh's P2P network (automatic NAT traversal)
 3. **Server**: Proxies connections to local SSH daemon running on (e.g. port localhost:22) (requires ssh server)
 4. **Authentication**: Standard SSH security applies end-to-end. The tunnel is ontop of that an encrypted QUIC connection.
 
@@ -207,14 +208,14 @@ Display its Node ID and share it to allow connection
 ## Security Model
 
 - **Node ID access**: Anyone with the Node ID can reach your SSH port
-- **SSH authentication**: ATM only password auth is supported
+- **SSH authentication**: SSH certificates and password auth are supported
 - **Persistent keys**: Uses dedicated `.ssh/iroh_ssh_ed25519` keypair
 - **QUIC encryption**: Transport layer encryption between endpoints
 
 ## Status
 
 - [x] Password authentication
-- [x] Persistent SSH keys  
+- [x] Persistent SSH keys
 - [x] Linux service mode
 - [x] Add howto gifs
 - [x] Add -p flag for persistence

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[Español](README_es.md)
+[Español](README_es.md) [Portuguese](README_pt.md)
 # iroh-ssh
 
 [![Crates.io](https://img.shields.io/crates/v/iroh-ssh.svg)](https://crates.io/crates/iroh-ssh)

--- a/README_es.md
+++ b/README_es.md
@@ -156,14 +156,14 @@ Mostrar su ID de nodo y compártalo para permitir la conexión
 
 ```
 ┌─────────────┐    ┌──────────────┐     ┌─────────────────┐     ┌─────────────┐
-│ iroh-ssh    │──▶│ Receptor     │───▶│ Tunel QUIC      │───▶│ servidor    │
+│ iroh-ssh    │───▶│ Receptor     │────▶│ Tunel QUIC      │────▶│ servidor    │
 │ (Su máquina)│    │ Interno TCP  │     │ (Red P2P)       │     │ iroh-ssh    │
 └─────────────┘    │ (Su máquina) │     └─────────────────┘     └─────────────┘
                    └──────────────┘
         │                  ▲                                           │
         ▼                  │                                           ▼
                    ┌──────────────┐                            ┌─────────────┐
-        ⦜   -- ▶  │ corre:   ssh │                            │ Servidor SSH│
+        ⦜   -- ▶   │ corre:   ssh │                            │ Servidor SSH│
                    │ user@localhost                            │ (puerto 22) │
                    └──────────────┘                            └─────────────┘
 ```

--- a/README_es.md
+++ b/README_es.md
@@ -1,4 +1,4 @@
-[English](README.md)
+[English](README.md) [Portuguese](README_pt.md)
 # iroh-ssh
 
 [![Crates.io](https://img.shields.io/crates/v/iroh-ssh.svg)](https://crates.io/crates/iroh-ssh)
@@ -158,7 +158,7 @@ Mostrar su ID de nodo y compártalo para permitir la conexión
 ┌─────────────┐    ┌──────────────┐     ┌─────────────────┐     ┌─────────────┐
 │ iroh-ssh    │───▶│ Receptor     │────▶│ Tunel QUIC      │────▶│ servidor    │
 │ (Su máquina)│    │ Interno TCP  │     │ (Red P2P)       │     │ iroh-ssh    │
-└─────────────┘    │ (Su máquina) │     └─────────────────┘     └─────────────┘
+└─────────────┘    │ (Su Este es un mismo documento en su versión en Ingles y Español. Hacer una versión de en portugués (universal, que favorezca portugués de Brasil, pero entendible en portugués de Portugal). Respetar el inglés existente donde están los comandos y código, tal y  como está en la versión en Español.máquina) │     └─────────────────┘     └─────────────┘
                    └──────────────┘
         │                  ▲                                           │
         ▼                  │                                           ▼
@@ -199,7 +199,6 @@ Mostrar su ID de nodo y compártalo para permitir la conexión
 # Conexión de cliente
 > iroh-ssh user@<NODE_ID>                           # Conectarse a un servidor remoto
 > iroh-ssh connect user@<NODE_ID>                   # Comando de conexión explicito
-> iroh-ssh connect user@<NODE_ID>                   # Comando de conexión explicito
 > iroh-ssh -i ~/.ssh/id_rsa_my_cert user@<NODE_ID>  # Conectarse con certificado
 > iroh-ssh -L [bind_address:]port:host:hostport user@<NODE_ID>  # Redireccionamiento de conexión del cliente (bind_addr:port) al servidor (host:hostport)
 > iroh-ssh -R [bind_address:]port:host:hostport user@<NODE_ID>  # Redireccionamiento de conexión del servidor (bind_addr:port) al cliente (host:hostport)
@@ -222,7 +221,7 @@ Mostrar su ID de nodo y compártalo para permitir la conexión
 - [x] Adicionar la opción -p para persistencia
 - [x] Modo servicio en Windows
 - [x] Soporte de certificados (opción `-i`)
-- [x] Modo servicio en MacOS
+- [ ] Modo servicio en MacOS
 - [ ] Funcionalidades adicionales SSH
 
 ## Licencia

--- a/README_pt.md
+++ b/README_pt.md
@@ -1,0 +1,229 @@
+[Español](README_es.md) [Portuguese](README_pt.md)
+# iroh-ssh
+
+[![Crates.io](https://img.shields.io/crates/v/iroh-ssh.svg)](https://crates.io/crates/iroh-ssh)
+[![Documentation](https://docs.rs/iroh-ssh/badge.svg)](https://docs.rs/iroh-ssh)
+[![License](https://img.shields.io/badge/license-MIT%2FApache--2.0-blue.svg)](LICENSE)
+
+**Acesse qualquer máquina sem IP, atrás de um NAT/firewall, sem redirecionamento de portas ou configuração de VPN.**
+
+```bash
+# No servidor
+> iroh-ssh server --persist
+
+    Connect to this this machine:
+
+    iroh-ssh my-user@bb8e1a5661a6dfa9ae2dd978922f30f524f6fd8c99b3de021c53f292aae74330
+
+
+# No cliente
+> iroh-ssh user@bb8e1a5661a6dfa9ae2dd978922f30f524f6fd8c99b3de021c53f292aae74330
+# o con certificados ssh
+> iroh-ssh -i ~/.ssh/id_rsa_my_cert my-user@bb8e1a5661a6dfa9ae2dd978922f30f524f6fd8c99b3de021c53f292aae74330
+```
+
+**Isso é tudo o que você precisa.** (requer que o SSH (ou um servidor SSH) esteja instalado)
+
+---
+
+## Instalação
+
+```bash
+cargo install iroh-ssh
+```
+
+Baixe e configure automaticamente o binário para o seu sistema operacional a partir das  [GitHub Releases](https://github.com/rustonbsd/iroh-ssh/releases):
+
+Linux
+```bash
+# Linux
+wget https://github.com/rustonbsd/iroh-ssh/releases/download/0.2.5/iroh-ssh.linux
+chmod +x iroh-ssh.linux
+sudo mv iroh-ssh.linux /usr/local/bin/iroh-ssh
+```
+
+macOS
+```bash
+# macOS arm
+curl -LJO https://github.com/rustonbsd/iroh-ssh/releases/download/0.2.5/iroh-ssh.macos
+chmod +x iroh-ssh.macos
+sudo mv iroh-ssh.macos /usr/local/bin/iroh-ssh
+```
+
+Windows
+```bash
+# Windows x86 64bit
+curl -L -o iroh-ssh.exe https://github.com/rustonbsd/iroh-ssh/releases/download/0.2.5/iroh-ssh.exe
+mkdir %LOCALAPPDATA%\iroh-ssh
+move iroh-ssh.exe %LOCALAPPDATA%\iroh-ssh\
+setx PATH "%PATH%;%LOCALAPPDATA%\iroh-ssh"
+```
+
+Verifique se a instalação foi bem-sucedida
+```bash
+# reinicie o terminal primeiro
+> iroh-ssh --help
+```
+
+---
+
+## Conexão do cliente
+
+```bash
+# Instale para sua distribuição primeiro (veja acima)
+# Conecte-se de qualquer lugar
+> iroh-ssh my-user@38b7dc10df96005255c3beaeaeef6cfebd88344aa8c85e1dbfc1ad5e50f372ac
+```
+
+Funciona através de qualquer firewall, NAT ou rede privada. Nenhuma configuração necessária.
+
+![Conectando ao servidor remoto](/media/t-rec_connect.gif)
+<br>
+(**vídeo um pouco desatualizado**)
+
+
+---
+
+## Configuração do servidor
+
+```bash
+# Instale para sua distribuição primeiro (veja acima)
+# (use com tmux ou instale como serviço no Linux)
+
+> iroh-ssh server --persist
+
+    Connect to this this machine:
+
+    iroh-ssh my-user@bb8e1a5661a6dfa9ae2dd978922f30f524f6fd8c99b3de021c53f292aae74330
+
+    (using persistent keys in /home/my-user/.ssh/irohssh_ed25519)
+
+    Server listening for iroh connections...
+    client -> iroh-ssh -> direct connect -> iroh-ssh -> local ssh :22
+    Waiting for incoming connections...
+    Press Ctrl+C to exit
+
+```
+
+ou use chaves efêmeras
+
+```bash
+# Instale para sua distribuição primeiro (veja acima)
+# (use com tmux ou instale como serviço no Linux)
+
+> iroh-ssh server
+
+    Connect to this this machine:
+
+    iroh-ssh my-user@bb8e1a5661a6dfa9ae2dd978922f30f524f6fd8c99b3de021c53f292aae74330
+
+    warning: (using ephemeral keys, run 'iroh-ssh server --persist' to create persistent keys)
+
+    client -> iroh-ssh -> direct connect -> iroh-ssh -> local ssh :22
+    Waiting for incoming connections...
+    Press Ctrl+C to exit
+    Server listening for iroh connections...
+
+```
+
+Exiba seu ID de nó e compartilhe-o para permitir a conexão
+
+![Iniciando o servidor/Instalando como serviço](/media/t-rec_server_service.gif)
+<br>
+(**vídeo um pouco desatualizado**)
+
+## Informações da conexão
+```bash
+// nota: funciona apenas com chaves persistentes
+> iroh-ssh info
+
+    Your iroh-ssh nodeid: 38b7dc10df96005255c3beaeaeef6cfebd88344aa8c85e1dbfc1ad5e50f372ac
+    iroh-ssh version 0.2.4
+    https://github.com/rustonbsd/iroh-ssh
+
+    Your server iroh-ssh nodeid:
+      iroh-ssh my-user@38b7dc10df96005255c3beaeaeef6cfebd88344aa8c85e1dbfc1ad5e50f372ac
+
+    Your service iroh-ssh nodeid:
+      iroh-ssh my-user@4fjeeiui4jdm96005255c3begj389xk3aeaeef6cfebd88344aa8c85e1dbfc1ad
+```
+
+---
+
+
+
+## Como funciona
+
+```
+┌─────────────┐    ┌──────────────┐     ┌─────────────────┐     ┌─────────────┐
+│ iroh-ssh    │───▶│ Receptor     │────▶│ Túnel QUIC      │────▶│ servidor    │
+│(Sua máquina)│    │ Interno TCP  │     │ (Rede P2P)      │     │ iroh-ssh    │
+└─────────────┘    │(Sua máquina) │     └─────────────────┘     └─────────────┘
+                   └──────────────┘
+        │                  ▲                                           │
+        ▼                  │                                           ▼
+                   ┌──────────────┐                            ┌─────────────┐
+        ⦜   -- ▶   │  exec:   ssh │                            │ Servidor SSH│
+                   │ user@localhost                            │ (porto 22)  │
+                   └──────────────┘                            └─────────────┘
+```
+
+1. **Cliente**: Cria um receptor TCP local, conecta o cliente SSH do sistema a ele
+2. **Túnel**: Conexão QUIC através da rede P2P do Iroh (travessia automática de NAT)
+3. **Servidor**: Encaminha a conexão para o daemon SSH que está rodando localmente (por exemplo, porta localhost:22)
+4. **Autenticação**: A segurança padrão do SSH é aplicada de ponta a ponta. O túnel está sobre uma conexão QUIC criptografada.
+
+## Casos de uso
+
+- **Servidores remotos**: Acesse instâncias em nuvem sem expor portas SSH
+- **Redes domésticas**: Conecte-se a dispositivos atrás de roteadores/firewalls
+- **Redes corporativas**: Contornar políticas restritivas de rede
+- **Dispositivos IoT**: SSH em sistemas embarcados em redes privadas
+- **Desenvolvimento**: Acesse servidores de teste e máquinas de compilação
+
+## Comandos
+
+```bash
+# Obtenha seu ID de nó e informações
+> iroh-ssh info
+
+# Modos de servidor
+> iroh-ssh server --persist          # Modo interativo, por exemplo use tmux (porto SSH padrão 22)
+> iroh-ssh server --ssh-port 2222    # Usando porta SSH personalizada (com chaves efêmeras)
+
+# Modo serviço
+> iroh-ssh service install                   # Daemon em segundo plano (apenas Linux e Windows, porta padrão 22)
+> iroh-ssh service install --ssh-port 2222   # Daemon em segundo plano com porta SSH personalizada
+> iroh-ssh service uninstall                 # Desinstalar serviço
+
+# Conexão do cliente
+> iroh-ssh user@<NODE_ID>                           # Conectar-se a um servidor remoto
+> iroh-ssh connect user@<NODE_ID>                   # Comando de conexão explícito
+> iroh-ssh -i ~/.ssh/id_rsa_my_cert user@<NODE_ID>  # Conectar-se com certificado
+> iroh-ssh -L [bind_address:]port:host:hostport user@<NODE_ID>  # Redirecionamento de conexão do cliente (bind_addr:port) para o servidor (host:hostport)
+> iroh-ssh -R [bind_address:]port:host:hostport user@<NODE_ID>  # Redirecionamento de conexão do servidor (bind_addr:port) para o cliente (host:hostport)
+
+```
+
+## Modelo de segurança
+
+- **Acesso por ID de nó**: Qualquer pessoa com o ID de nó pode acessar sua porta SSH
+- **Autenticação SSH**: São suportadas autenticação por senha e certificados SSH
+- **Chaves persistentes**: Usa um par de chaves dedicado em `.ssh/iroh_ssh_ed25519`
+- **Criptografia QUIC**: Criptografia na camada de transporte entre pontos finais
+
+## Avances
+
+- [x] Autenticação por senha
+- [x] Chaves SSH persistentes
+- [x] Modo serviço no Linux
+- [x] Adicionar gifs com exemplos
+- [x] Adicionar flag -p para persistência
+- [x] Modo serviço no Windows
+- [x] Suporte a certificados (flag -i)
+- [ ] Modo serviço no macOS
+- [ ] Recursos SSH adicionais
+
+## Licença
+
+Licenciado sob a Apache License 2.0 ou a MIT License, conforme sua escolha.


### PR DESCRIPTION
With minor content fixes on the English version of the README markdown file, this add tab-like links with the Spanish and Portuguese versions.

Disclaimer: An LLM model was used for spellcheck and style review of the Portuguese version. (Qwen3 small MOE, self-hosted agent)