### PR TITLE
refactor to work with all ssh options

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ Display its Node ID and share it to allow connection
 ## Security Model
 
 - **Node ID access**: Anyone with the Node ID can reach your SSH port
-- **SSH authentication**: SSH certificates and password auth are supported
+- **SSH authentication**: SSH key file, certificate and password auth are supported
 - **Persistent keys**: Uses dedicated `.ssh/iroh_ssh_ed25519` keypair
 - **QUIC encryption**: Transport layer encryption between endpoints
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,0 +1,136 @@
+use std::{ffi::OsString, path::PathBuf};
+
+use clap::{command, ArgAction, Args, Parser, Subcommand};
+
+const TARGET_HELP: &str = "Target in the form user@NODE_ID";
+
+#[derive(Parser)]
+#[command(
+    name = "iroh-ssh",
+    about = "ssh without ip",
+)]
+pub struct Cli {
+    #[command(subcommand)]
+    pub cmd: Option<Cmd>,
+
+    #[arg(help = TARGET_HELP)]
+    pub target: Option<String>,
+
+    #[command(flatten)]
+    pub ssh: SshOpts,
+
+    #[arg(trailing_var_arg = true)]
+    pub remote_cmd: Option<Vec<OsString>>,
+}
+
+#[derive(Subcommand)]
+pub enum Cmd {
+    Connect(ConnectArgs),
+    Exec(ExecArgs),
+    Server(ServerArgs),
+    Service {
+        #[command(subcommand)]
+        op: ServiceCmd,
+    },
+    Info,
+    Proxy(ProxyArgs),
+}
+
+#[derive(Args, Clone)]
+pub struct ProxyArgs {
+    #[arg(help = "Proxy node ID")]
+    pub node_id: String,
+}
+
+#[derive(Args, Clone)]
+pub struct ConnectArgs {
+    #[arg(help = TARGET_HELP)]
+    pub target: String,
+
+    #[command(flatten)]
+    pub ssh: SshOpts,
+
+    #[arg(trailing_var_arg = true)]
+    pub remote_cmd: Vec<OsString>,
+}
+
+#[derive(Args, Clone)]
+pub struct ExecArgs {
+    #[arg(help = TARGET_HELP)]
+    pub target: String,
+
+    #[command(flatten)]
+    pub ssh: SshOpts,
+
+    #[arg(trailing_var_arg = true, required = true)]
+    pub remote_cmd: Vec<OsString>,
+}
+
+#[derive(Args, Clone, Default)]
+pub struct SshOpts {
+    #[arg(short = 'i', long, value_name = "PATH",
+        help = "Identity file for publickey auth")]
+    pub identity_file: Option<PathBuf>,
+
+    #[arg(short = 'L', value_name = "LPORT:HOST:RPORT",
+        help = "Local forward [bind_addr:]lport:host:rport (host can't be node_id yet)", action = ArgAction::Append)]
+    pub local_forward: Vec<String>,
+
+    #[arg(short = 'R', value_name = "RPORT:HOST:LPORT",
+        help = "Remote forward [bind_addr:]rport:host:lport  (host can't be node_id yet)", action = ArgAction::Append)]
+    pub remote_forward: Vec<String>,
+
+    #[arg(short = 'p', long, value_name = "PORT",
+        help = "Remote sshd port (default 22)")]
+    pub port: Option<u16>,
+
+    #[arg(short = 'o', value_name = "KEY=VALUE",
+        help = "Pass an ssh option (repeatable)", action = ArgAction::Append)]
+    pub options: Vec<String>,
+
+    #[arg(short = 'A', help = "Enable agent forwarding", action = ArgAction::SetTrue)]
+    pub agent: bool,
+
+    #[arg(short = 'a', help = "Disable agent forwarding", action = ArgAction::SetTrue)]
+    pub no_agent: bool,
+
+    #[arg(short = 'X', help = "Enable X11 forwarding", action = ArgAction::SetTrue)]
+    pub x11: bool,
+
+    #[arg(short = 'Y', help = "Enable trusted X11 forwarding", action = ArgAction::SetTrue)]
+    pub x11_trusted: bool,
+
+    #[arg(short = 'N', help = "Do not execute remote command", action = ArgAction::SetTrue)]
+    pub no_cmd: bool,
+
+    #[arg(short = 't', help = "Force pseudo-terminal", action = ArgAction::SetTrue)]
+    pub force_tty: bool,
+
+    #[arg(short = 'T', help = "Disable pseudo-terminal", action = ArgAction::SetTrue)]
+    pub no_tty: bool,
+
+    #[arg(short = 'v', help = "Increase verbosity",
+        action = ArgAction::Count)]
+    pub verbose: u8,
+
+    #[arg(short = 'q', help = "Quiet mode", action = ArgAction::SetTrue)]
+    pub quiet: bool,
+}
+
+#[derive(Args, Clone)]
+pub struct ServerArgs {
+    #[arg(long, default_value = "22")]
+    pub ssh_port: u16,
+
+    #[arg(short, long, default_value_t = false)]
+    pub persist: bool,
+}
+
+#[derive(Subcommand, Clone)]
+pub enum ServiceCmd {
+    Install {
+        #[arg(long, default_value = "22")]
+        ssh_port: u16,
+    },
+    Uninstall,
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod api;
 mod service;
 mod ssh;
+mod cli;
 
 use ed25519_dalek::{PUBLIC_KEY_LENGTH, SECRET_KEY_LENGTH};
 use iroh::{Endpoint, protocol::Router};
@@ -9,6 +10,7 @@ pub use service::Service;
 pub use service::ServiceParams;
 pub use service::{install_service, uninstall_service};
 pub use ssh::dot_ssh;
+pub use cli::*;
 
 #[derive(Debug, Clone)]
 pub struct IrohSsh {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,160 +1,36 @@
-use std::path::PathBuf;
-
-use clap::{Args, Parser, Subcommand, command};
-use iroh_ssh::api::{self, ClientOptions};
-
-const TARGET_HELP: &str = "The host to connect to";
-
-#[derive(Parser)]
-#[command(
-    name = "irohssh",
-    about = "SSH without IP",
-    after_help = "
-Server:
-  // Start server with persistent keys in home directory (~/.ssh/irohssh_ed25519)
-  iroh-ssh server --persist
-
-  // Start server with ephemeral keys (useful for testing or short-lived connections)
-  iroh-ssh server
-
-Connect:
-  // Connect to server
-  iroh-ssh my-user@6598395384059bf969...
-  or 
-  iroh-ssh connect ...
-
-  // Identity file
-  iroh-ssh -i ~/.ssh/id_rsa_my_cert ...
-
-  // Tunneling
-  iroh-ssh -L localhost:8000:123.45.67.89:9000 ...
-  iroh-ssh -R 123.45.67.89:9000:localhost:8000 ...
-
-Service:
-  // Install as service (linux and windows only, uses persistent keys)
-  iroh-ssh service install
-
-  // Uninstall service
-  iroh-ssh service uninstall
-
-Info:
-  // Display connection information if keys are persisted
-  iroh-ssh info
-"
-)]
-struct Cli {
-    #[command(subcommand)]
-    cli_command: Option<Commands>,
-    #[arg(help = TARGET_HELP)]
-    target: Option<String>,
-    #[command(flatten)]
-    ssh_args: ConnectArgs,
-    #[arg(help = "Command to be executed on the target", trailing_var_arg = true)]
-    execute_command: Option<Vec<String>>,
-}
-
-#[derive(Subcommand)]
-enum Commands {
-    #[command(
-        about = "Connect to a remote server - iroh-ssh `connect` my-user@NODE_ID [command (optional)]"
-    )]
-    Connect {
-        #[arg(help = TARGET_HELP)]
-        target: String,
-        #[command(flatten)]
-        ssh_args: ConnectArgs,
-        #[arg(help = "Command to be executed on the target")]
-        execute_command: Vec<String>,
-    },
-    #[command(about = "Run as server (for example in a tmux session)")]
-    Server {
-        #[arg(long, default_value = "22")]
-        ssh_port: u16,
-        #[arg(short, long, default_value = "false")]
-        persist: bool,
-    },
-    #[command(about = "Manage service (linux and windows only, uses persistent keys)")]
-    Service {
-        #[command(subcommand)]
-        service_command: ServiceCommands,
-    },
-    #[command(about = "Display connection information")]
-    Info {},
-}
-
-#[derive(Args)]
-struct ConnectArgs {
-    #[arg(
-        short = 'i',
-        long,
-        help = "Selects a file from which the identity (private key) for RSA or DSA authentication is read."
-    )]
-    identity_file: Option<PathBuf>,
-    #[arg(
-        short = 'L',
-        long,
-        help = "[bind_address:]port:host:hostport - Specifies that the given port on the local (client) host is to be forwarded to the given host and port on the remote side. Only the superuser can forward privileged ports. By default, the local port is bound in accordance with the GatewayPorts setting."
-    )]
-    local_forward: Option<String>,
-    #[arg(
-        short = 'R',
-        long,
-        help = "[bind_address:]port:host:hostport - Specifies that the given port on the remote (server) host is to be forwarded to the given host and port on the local side. Specifying a remote bind_address will only succeed if the server's GatewayPorts option is enabled in the ssh server config."
-    )]
-    remote_forward: Option<String>,
-}
-
-impl ConnectArgs {
-    fn into_client_options(self, target: String) -> ClientOptions {
-        ClientOptions {
-            target,
-            identity_file: self.identity_file,
-            local_forward: self.local_forward,
-            remote_forward: self.remote_forward,
-        }
-    }
-}
-
-#[derive(Subcommand)]
-enum ServiceCommands {
-    #[command(about = "Run as service (linux and windows only, uses persistent keys)")]
-    Install {
-        #[arg(long, default_value = "22")]
-        ssh_port: u16,
-    },
-    Uninstall {},
-}
+use clap::Parser;
+use iroh_ssh::{Cli, Cmd, ConnectArgs, ServiceCmd, api};
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     let cli = Cli::parse();
 
-    match (cli.cli_command, cli.target) {
-        (
-            Some(Commands::Connect {
-                target,
-                ssh_args,
-                execute_command,
-            }),
-            _,
-        ) => api::client_mode(ssh_args.into_client_options(target), execute_command).await,
-        (Some(Commands::Server { ssh_port, persist }), _) => {
-            api::server_mode(ssh_port, persist).await
+    match cli.cmd {
+        Some(Cmd::Connect(args)) => api::client_mode(args).await,
+        Some(Cmd::Exec(args)) => {
+            let conn_args = ConnectArgs {
+                ssh: args.ssh,
+                remote_cmd: args.remote_cmd,
+                target: args.target,
+            };
+            api::client_mode(conn_args).await
         }
-        (Some(Commands::Service { service_command }), _) => match service_command {
-            ServiceCommands::Install { ssh_port } => api::service::install(ssh_port).await,
-            ServiceCommands::Uninstall {} => api::service::uninstall().await,
+        Some(Cmd::Server(args)) => api::server_mode(args).await,
+        Some(Cmd::Service { op }) => match op {
+            ServiceCmd::Install { ssh_port } => api::service::install(ssh_port).await,
+            ServiceCmd::Uninstall => api::service::uninstall().await,
         },
-        (Some(Commands::Info {}), _) => api::info_mode().await,
-        (None, Some(target)) => {
-            api::client_mode(
-                cli.ssh_args.into_client_options(target),
-                cli.execute_command.unwrap_or_default(),
-            )
-            .await
+        Some(Cmd::Info) => api::info_mode().await,
+        Some(Cmd::Proxy(args)) => {
+            api::proxy_mode(args).await
         }
-        (None, None) => {
-            anyhow::bail!("Please provide a target or use the 'connect' subcommand")
+        None => {
+            let conn_args = ConnectArgs {
+                ssh: cli.ssh,
+                remote_cmd: cli.remote_cmd.unwrap_or_default(),
+                target: cli.target.expect("target is required"),
+            };
+            api::client_mode(conn_args).await
         }
     }
 }


### PR DESCRIPTION
main work:
- [x] refactor clap cli
- [x] add passthrough with `--` to enable **all** ssh options (no fully compatible)
- [x] get rid of 127.0.0.1 proxy and replace with `ProxyCommand`
- [ ] adjust binary --help + rest binary print's
- [ ] adjust README.md 
- [ ] translate changed parts of README.md to spanish and portuguese (@rjmalagon can you help with that again? i will let you know via mention in a comment in this PR if you have some time)

--- 

final steps:
- [ ] test backwards compatibility
- [ ] thurow cross platform testing
- [ ] release draft
- [ ] crates.io
- [ ] release

NOTE: maintain complete compatibility when it comes to the cli (and ideally all of the rest)