### PR TITLE
added simple version command

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -35,6 +35,7 @@ pub enum Cmd {
     Proxy(ProxyArgs),
     #[command(hide = true)]
     RunService(ServiceArgs),
+    Version,
 }
 
 #[derive(Args, Clone, Debug)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -31,6 +31,10 @@ async fn main() -> anyhow::Result<()> {
             }
         }
         Some(Cmd::Info) => api::info_mode().await,
+        Some(Cmd::Version) => {
+            println!("iroh-ssh version {}", env!("CARGO_PKG_VERSION"));
+            Ok(())
+        },
         Some(Cmd::Proxy(args)) => api::proxy_mode(args).await,
         #[cfg(target_os = "windows")]
         Some(Cmd::RunService(args)) => iroh_ssh::run_service(args.ssh_port).await,


### PR DESCRIPTION
I am working on packaging `iroh-ssh` for Nix, so that myself and others may use it there conveniently. One of the default tests that Nix runs when building packages is to run a version command and check that the proper version string shows up. I figured this would be a simple change and possibly useful on its own. 

I will link my nixpkgs work here when it is complete!